### PR TITLE
Add automatic linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+---
+
+name: Ansible lint
+
+on:  # yamllint disable-line rule:truthy
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install dependencies
+        run: >
+          pip3 install
+          ansible
+          ansible-lint
+          yamllint
+
+      - run: ansible-lint
+
+      - run: yamllint --strict .


### PR DESCRIPTION
This patch adds a GitHub Actions workflow to automatically run `ansible-lint` and `yamllint` on all pushes and pull requests.