### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
This patch adds a Dependabot configuration to automate updating GitHub Actions if updates are available.