### PR TITLE
Always delegate to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Example of how to configure and use the role:
 
 ```yaml
 - name: Verify Galaxy Roles
-  hosts: localhost
+  hosts: all
   connection: local
   gather_facts: false
   roles:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,4 +3,6 @@
 - name: Verify versions
   ansible.builtin.command:
     cmd: '{{ role_path }}/files/verify-galaxy-versions'
+  delegate_to: localhost
+  run_once: true
   changed_when: false


### PR DESCRIPTION
Instead of relying on the user properly including this role, this patch ensures that:

- the test always runs on localhost
- the task runs regardless of the inventory you define
- the task runs only once regardless of the number of hosts