### PR TITLE
Do not require root

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,4 +5,5 @@
     cmd: '{{ role_path }}/files/verify-galaxy-versions'
   delegate_to: localhost
   run_once: true
+  become: false
   changed_when: false


### PR DESCRIPTION
This patch ensures that we do not try running the check as root. This should run locally and should always run as the user we execute ansible with.